### PR TITLE
Fix PHP 8.4 compatibility issues

### DIFF
--- a/Block/Adminhtml/Product/Widget/Chooser.php
+++ b/Block/Adminhtml/Product/Widget/Chooser.php
@@ -30,13 +30,13 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser
      * @param array $data
      */
     public function __construct(
-        private Context $context,
-        private Data $backendHelper,
-        private CategoryFactory $categoryFactory,
-        private CollectionFactory $collectionFactory,
-        private Category $resourceCategory,
-        private Product $resourceProduct,
-        private StoreManagerInterface $storeManager,
+        protected Context $context,
+        protected Data $backendHelper,
+        protected CategoryFactory $categoryFactory,
+        protected CollectionFactory $collectionFactory,
+        protected Category $resourceCategory,
+        protected Product $resourceProduct,
+        protected StoreManagerInterface $storeManager,
         array $data = []
     ) {
         parent::__construct(
@@ -171,6 +171,8 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser
                 }
             ';
         }
+
+        return '';
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.2
+### Fixed
+- Fix getRowClickCallback() returning null instead of string when massaction is enabled
+- Change private constructor properties to protected for extensibility
+
 ## 1.1.1
 ## Fixed
 - Unset missing products from repeatable fields during widget configuration rendering


### PR DESCRIPTION
## Summary
- Fix getRowClickCallback() returning null instead of string when massaction is enabled
- Change private constructor properties to protected for extensibility

## Changes
- **Chooser.php**: added return empty string fallback when getUseMassaction() is truthy, preventing TypeError with strict_types
- **Chooser.php**: changed 7 private promoted properties to protected
- **CHANGELOG.md**: added 1.1.2 entry

## Suggested release
This could be tagged as 1.1.2 (patch release).