### PR TITLE
PHP 8.5 compatibility and protected visibility cleanup

### DIFF
--- a/Block/Adminhtml/Product/Widget/Chooser.php
+++ b/Block/Adminhtml/Product/Widget/Chooser.php
@@ -76,7 +76,7 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser
      */
     public function prepareElementHtml(AbstractElement $element): AbstractElement
     {
-        $uniqId = $this->mathRandom->getUniqueHash($element->getId());
+        $uniqId = $this->mathRandom->getUniqueHash((string)$element->getId());
         $sourceUrl = $this->getUrl(
             'advanced_widget/product_widget/chooser',
             ['uniq_id' => $uniqId, 'use_massaction' => false]
@@ -97,7 +97,7 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser
         );
 
         if ($element->getValue()) {
-            $value = explode('/', $element->getValue());
+            $value = explode('/', (string)$element->getValue());
             $productId = false;
             if (isset($value[0]) && isset($value[1]) && $value[0] == 'product') {
                 $productId = $value[1];

--- a/Block/Adminhtml/Product/Widget/Grid/Column/Renderer/Image.php
+++ b/Block/Adminhtml/Product/Widget/Grid/Column/Renderer/Image.php
@@ -20,9 +20,9 @@ class Image extends AbstractRenderer
      * @param array $data
      */
     public function __construct(
-        private Context $context,
-        private ProductRepositoryInterface $productRepository,
-        private ImageHelper $imageHelper,
+        protected Context $context,
+        protected ProductRepositoryInterface $productRepository,
+        protected ImageHelper $imageHelper,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -43,6 +43,6 @@ class Image extends AbstractRenderer
         if (!$imageUrl) {
             return '';
         }
-        return '<img src="' . $imageUrl . '" width="75" height="75" alt="' . $row->getName() . '"/>';
+        return '<img src="' . $imageUrl . '" width="75" height="75" alt="' . (string)$row->getName() . '"/>';
     }
 }

--- a/Block/Adminhtml/Renderer/Repeatable.php
+++ b/Block/Adminhtml/Renderer/Repeatable.php
@@ -44,12 +44,12 @@ class Repeatable extends Template implements FormElementRenderer
      * @param array $data
      */
     public function __construct(
-        private Context $context,
-        private Http $request,
-        private ProductRepositoryInterface $productRepository,
-        private CollectionFactory $productCollectionFactory,
-        private ImageHelper $imageHelper,
-        private array $customFields = [],
+        protected Context $context,
+        protected Http $request,
+        protected ProductRepositoryInterface $productRepository,
+        protected CollectionFactory $productCollectionFactory,
+        protected ImageHelper $imageHelper,
+        protected array $customFields = [],
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -125,7 +125,7 @@ class Repeatable extends Template implements FormElementRenderer
      */
     public function getParameterName()
     {
-        $parameterName = $this->element->getName();
+        $parameterName = (string)$this->element->getName();
         if (preg_match('/\[(.*?)\]/', $parameterName, $matches) && isset($matches[1])) {
             $parameterName = $matches[1];
         }
@@ -158,7 +158,7 @@ class Repeatable extends Template implements FormElementRenderer
             $values = json_encode($rows);
             return json_decode($values, true) ?: [];
         } else {
-            $values = str_replace("'", '"', $this->getElement()->getValue());
+            $values = str_replace("'", '"', (string)$this->getElement()->getValue());
             return json_decode(str_replace("&#039;", '"', $values), true) ?: [];
         }
     }

--- a/Block/WidgetField/Rows.php
+++ b/Block/WidgetField/Rows.php
@@ -41,7 +41,7 @@ class Rows extends Template
     {
         /** @var Repeatable $fieldRenderer */
         $fieldRenderer = $this->getLayout()->createBlock(Repeatable::class);
-        if(str_contains($element->getName(),'repeatable_') && !empty($element->getValue())) {
+        if (str_contains((string)$element->getName(), 'repeatable_') && !empty($element->getValue())) {
             $element->setData('value', $this->conditions->decode($element->getValue()));
         }
         $fieldRenderer->setRows($this->rows);

--- a/Block/WidgetField/TextArea.php
+++ b/Block/WidgetField/TextArea.php
@@ -17,7 +17,7 @@ class TextArea extends \Magento\Backend\Block\Template
      */
     public function __construct(
         Context $context,
-        private Factory $elementFactory,
+        protected Factory $elementFactory,
         array $data = []
     ) {
         parent::__construct($context, $data);

--- a/Block/WidgetField/Title.php
+++ b/Block/WidgetField/Title.php
@@ -13,7 +13,7 @@ class Title extends Template implements FormElementRenderer
     /**
      * @var AbstractElement
      */
-    private AbstractElement $element;
+    protected AbstractElement $element;
 
     /**
      * @var string
@@ -45,7 +45,7 @@ class Title extends Template implements FormElementRenderer
      */
     public function getValues(): mixed
     {
-        $values = $this->getElement()->getValue();
+        $values = (string)$this->getElement()->getValue();
         return json_decode(urldecode($values), true) ?: [];
     }
 }

--- a/Block/Widgets/AbstractColumns.php
+++ b/Block/Widgets/AbstractColumns.php
@@ -19,7 +19,7 @@ class AbstractColumns extends Template implements BlockInterface
      * @param array $data
      */
     public function __construct(
-        private Conditions $conditionsHelper,
+        protected Conditions $conditionsHelper,
         Context $context,
         array $data = []
     ) {
@@ -88,12 +88,12 @@ class AbstractColumns extends Template implements BlockInterface
      */
     public function getImageUrl(string $imageField = 'image'): string
     {
-        $url = $this->getData($imageField);
+        $url = (string)$this->getData($imageField);
         if (!$url) {
             return '';
         }
 
-        if (strpos($url, $this->getMediaUrl()) !== 0) {
+        if (!str_starts_with($url, $this->getMediaUrl())) {
             return $this->getMediaUrl() . '/' . $url;
         }
 
@@ -117,8 +117,9 @@ class AbstractColumns extends Template implements BlockInterface
      */
     public function getPreparedUrl($urlLink): string
     {
+        $urlLink = (string)$urlLink;
         $preparedLink = $urlLink;
-        if (strpos($urlLink, 'http') === false) {
+        if (!str_contains($urlLink, 'http')) {
             $urlLink = explode('?', $urlLink);
             $preparedLink = $this->getUrl(trim($urlLink[0], '/'));
             if (!empty($urlLink[1])) {
@@ -134,6 +135,6 @@ class AbstractColumns extends Template implements BlockInterface
      */
     public function getPreparedDescription(string $descriptionField = 'description'): string
     {
-        return str_replace('\EOL', '<br />', $this->getData($descriptionField));
+        return str_replace('\EOL', '<br />', (string)$this->getData($descriptionField));
     }
 }

--- a/Block/Widgets/Template.php
+++ b/Block/Widgets/Template.php
@@ -98,7 +98,7 @@ class Template extends \Magento\Framework\View\Element\Template implements \Mage
             [$parameter, $empty, $negate, $name] = $match;
 
             $regex = isset($match[4]) ? "/^({$match[4]})$/" : '';
-            $value = $params[$name] ?? '';
+            $value = $params[(string)$name] ?? '';
             $result = $regex
                 ? preg_match($regex, $value)
                 : $value || (is_string($value) && $value !== '');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 1.2.0 - 2026-04-21
 ### Fixed
 - PHP 8.5 compatibility: cast nullable values to string before passing to `str_replace`, `strpos`, `str_contains`, `preg_match`, `explode`, `urldecode` and similar string functions to avoid deprecation notices and fatal errors
+- Cast nullable values to string/int before using as array index (PHP 8.5 null array key deprecation)
 - Replace deprecated `strpos` / `strpos(..., 'http') === false` usages with `str_starts_with` / `str_contains`
 - Add `declare(strict_types=1)` and missing return type hints to `Controller/Adminhtml/Image/Chooser`
 - Clean up redundant `$this->escaper = $escaper ?: ObjectManager::getInstance()->get(...)` fallback in `Controller/Adminhtml/Product/Widget/Chooser` (constructor already enforces non-null Escaper)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.2.0 - 2026-04-21
+### Fixed
+- PHP 8.5 compatibility: cast nullable values to string before passing to `str_replace`, `strpos`, `str_contains`, `preg_match`, `explode`, `urldecode` and similar string functions to avoid deprecation notices and fatal errors
+- Replace deprecated `strpos` / `strpos(..., 'http') === false` usages with `str_starts_with` / `str_contains`
+- Add `declare(strict_types=1)` and missing return type hints to `Controller/Adminhtml/Image/Chooser`
+- Clean up redundant `$this->escaper = $escaper ?: ObjectManager::getInstance()->get(...)` fallback in `Controller/Adminhtml/Product/Widget/Chooser` (constructor already enforces non-null Escaper)
+
+### Changed
+- Change remaining `private` promoted/regular properties to `protected` for consistent extensibility across all classes
+
 ## 1.1.2
 ### Fixed
 - Fix getRowClickCallback() returning null instead of string when massaction is enabled

--- a/Controller/Adminhtml/Image/Chooser.php
+++ b/Controller/Adminhtml/Image/Chooser.php
@@ -1,18 +1,19 @@
 <?php
+declare(strict_types=1);
 
 namespace MageOS\AdvancedWidget\Controller\Adminhtml\Image;
 
 use Magento\Backend\App\Action\Context;
 use Magento\Cms\Model\Wysiwyg\Images\GetInsertImageContent;
+use Magento\Framework\Controller\Result\Raw;
 use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class Chooser extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\OnInsert
 {
-    protected $resultRawFactory;
-
     /**
      * @param Context $context
      * @param Registry $coreRegistry
@@ -21,17 +22,20 @@ class Chooser extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\OnInsert
      * @param StoreManagerInterface $storeManager
      */
     public function __construct(
-        RawFactory $resultRawFactory,
-        private Context $context,
-        private Registry $coreRegistry,
-        private GetInsertImageContent $getInsertImageContent,
-        protected StoreManagerInterface $storeManager,
+        Context $context,
+        Registry $coreRegistry,
+        protected RawFactory $resultRawFactory,
+        protected GetInsertImageContent $getInsertImageContent,
+        protected StoreManagerInterface $storeManager
     ) {
-        $this->resultRawFactory = $resultRawFactory;
         parent::__construct($context, $coreRegistry, $resultRawFactory, $getInsertImageContent);
     }
 
-    public function execute()
+    /**
+     * @return Raw
+     * @throws NoSuchEntityException
+     */
+    public function execute(): Raw
     {
         $data = $this->getRequest()->getParams();
         $mediaUrl = $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_WEB);
@@ -41,8 +45,8 @@ class Chooser extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\OnInsert
             $data['as_is'],
             isset($data['store']) ? (int) $data['store'] : null
         );
-        $content = str_replace($mediaUrl, '', $content);
-        $content = '/'. ltrim($content, '/');
+        $content = str_replace($mediaUrl, '', (string)$content);
+        $content = '/' . ltrim($content, '/');
         return $this->resultRawFactory->create()->setContents($content);
     }
 }

--- a/Controller/Adminhtml/Product/Widget/Chooser.php
+++ b/Controller/Adminhtml/Product/Widget/Chooser.php
@@ -5,7 +5,6 @@ namespace MageOS\AdvancedWidget\Controller\Adminhtml\Product\Widget;
 
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Controller\Result\Raw;
 use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Escaper;
@@ -22,13 +21,12 @@ class Chooser extends \Magento\Backend\App\Action implements HttpPostActionInter
      * @param Escaper $escaper
      */
     public function __construct(
-        private Context $context,
-        private RawFactory $resultRawFactory,
-        private LayoutFactory $layoutFactory,
-        private Escaper $escaper
+        Context $context,
+        protected RawFactory $resultRawFactory,
+        protected LayoutFactory $layoutFactory,
+        protected Escaper $escaper
     ) {
         parent::__construct($context);
-        $this->escaper = $escaper ?: ObjectManager::getInstance()->get(Escaper::class);
     }
 
     /**
@@ -38,7 +36,7 @@ class Chooser extends \Magento\Backend\App\Action implements HttpPostActionInter
      */
     public function execute(): Raw
     {
-        $uniqId = $this->getRequest()->getParam('uniq_id');
+        $uniqId = (string)$this->getRequest()->getParam('uniq_id');
         $massAction = $this->getRequest()->getParam('use_massaction', false);
         $productTypeId = $this->getRequest()->getParam('product_type_id', null);
 

--- a/Plugin/WysiwygImagePlugin.php
+++ b/Plugin/WysiwygImagePlugin.php
@@ -16,11 +16,15 @@ class WysiwygImagePlugin
     /**
      * @var DirectoryRead
      */
-    private DirectoryRead $mediaDir;
+    protected DirectoryRead $mediaDir;
 
+    /**
+     * @param FileSystem $fileSystem
+     * @param RequestInterface $request
+     */
     public function __construct(
         FileSystem $fileSystem,
-        private RequestInterface $request
+        protected RequestInterface $request
     ) {
         $this->mediaDir = $fileSystem->getDirectoryRead(DirectoryList::MEDIA);
     }
@@ -69,7 +73,7 @@ class WysiwygImagePlugin
      * @param bool $renderAsTag
      * @return bool
      */
-    private function shouldResultBeRelativePath(bool $renderAsTag): bool
+    protected function shouldResultBeRelativePath(bool $renderAsTag): bool
     {
         if (!$renderAsTag && $this->request->getParam('widget')) {
             return true;


### PR DESCRIPTION
Hi @rhoerr, this PR brings the module up to full PHP 8.5 compatibility and completes the private -> protected migration started in 1.1.2. Would suggest tagging this as **1.2.0** once merged.

## Main fixes

### PHP 8.5 compatibility (implicit nullable -> string deprecations)
String functions in PHP 8.5 emit deprecation warnings when passed `null`. All call sites that could receive nullable values have been guarded with `(string)` casts:

- `str_replace(...)` on request params / block data
- `strpos(...)` / `str_contains(...)` / `str_starts_with(...)` on nullable strings
- `preg_match(...)` / `explode(...)` / `urldecode(...)` on nullable inputs

### Modernization
- Replaced legacy `strpos($haystack, $needle) === false` checks with `str_contains()` / `str_starts_with()` where appropriate
- Added `declare(strict_types=1)` and proper return type to `Controller/Adminhtml/Image/Chooser`
- Removed dead `ObjectManager::getInstance()` fallback in `Controller/Adminhtml/Product/Widget/Chooser` (the dependency is always injected)

### Visibility cleanup
- Converted the remaining `private` (and `private readonly`) promoted properties to `protected`, matching the convention established in 1.1.2 across the rest of the module.

## Files touched
- Block/Adminhtml/Product/Widget/Chooser.php
- Block/Adminhtml/Product/Widget/Grid/Column/Renderer/Image.php
- Block/Adminhtml/Renderer/Repeatable.php
- Block/WidgetField/Rows.php
- Block/WidgetField/TextArea.php
- Block/WidgetField/Title.php
- Block/Widgets/AbstractColumns.php
- Controller/Adminhtml/Image/Chooser.php
- Controller/Adminhtml/Product/Widget/Chooser.php
- Plugin/WysiwygImagePlugin.php
- CHANGELOG.md (new 1.2.0 entry)

Tested on Magento 2.4.8-p2 with PHP 8.5. Happy to adjust anything if the approach does not match your preferences.
