### PR TITLE
Issue #7 - Fix fatal error on redeclaration for properties

### DIFF
--- a/Controller/Adminhtml/Image/Chooser.php
+++ b/Controller/Adminhtml/Image/Chooser.php
@@ -24,8 +24,8 @@ class Chooser extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\OnInsert
     public function __construct(
         Context $context,
         Registry $coreRegistry,
-        protected RawFactory $resultRawFactory,
-        protected GetInsertImageContent $getInsertImageContent,
+        RawFactory $resultRawFactory,
+        GetInsertImageContent $getInsertImageContent,
         protected StoreManagerInterface $storeManager
     ) {
         parent::__construct($context, $coreRegistry, $resultRawFactory, $getInsertImageContent);


### PR DESCRIPTION
Fixes Issue #7 
Removes the protected attribute from $rawResultFactory & $getInsertImageContent to fix fatal php error in MageOS\AdvancedWidget\Controller\Adminhtml\Image\Chooser.